### PR TITLE
Impl get ticket

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -68,6 +68,7 @@
     "SHELL": "/bin/zsh",
     // Go application settings
     "TICKET_MGR_PORT": "8080",
+    "TICKET_QUERIER_PORT": "8081",
     "FIRESTORE_EMULATOR_HOST": "firestore:8200",
     "FIRESTORE_PROJECT_ID": "dummy-project-id"
   },

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Update ticket
 buf curl --http2-prior-knowledge --protocol grpc \
   http://localhost:8080/ticketmgr.v1.TicketMgrService/UpdateTicket \
   -d '{
-    "ticket_id": "3b227eab-47be-4fb6-bf25-797ae37ca35e",
+    "ticket_id": "some ticket id",
     "requested_by":"4e770fc1-0977-4ea9-911a-d67d4185817e",
     "title": "Updated Ticket",
     "description": "Updated ticket description.",
@@ -35,6 +35,26 @@ Delete ticket
 buf curl --http2-prior-knowledge --protocol grpc \
   http://localhost:8080/ticketmgr.v1.TicketMgrService/DeleteTicket \
   -d '{
-    "ticket_id": "3b227eab-47be-4fb6-bf25-797ae37ca35e"
+    "ticket_id": "some ticket id"
+  }'
+```
+
+List tickets
+
+```zsh
+buf curl --http2-prior-knowledge --protocol grpc \
+  http://localhost:8081/ticketquerier.v1.TicketQuerierService/QueryTickets \
+  -d '{
+    "requested_by": "8ea79f88-5b4b-4df6-b438-81a2ccf6b09f"
+  }'
+```
+
+Get ticket
+
+```zsh
+buf curl --http2-prior-knowledge --protocol grpc \
+  http://localhost:8081/ticketquerier.v1.TicketQuerierService/GetTicketById \
+  -d '{
+    "ticket_id": "some ticket id"
   }'
 ```

--- a/go/app/ticket/internal/querier/grpc_test.go
+++ b/go/app/ticket/internal/querier/grpc_test.go
@@ -135,7 +135,7 @@ func TestServer_QueryTickets(t *testing.T) {
 			wantErr assert.ErrorAssertionFunc
 		}{
 			"Context cancelled": {
-				ctx: ctxtest.CanceledContext(),
+				ctx: ctxtest.CanceledContext(), // important
 				wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
 					return assert.EqualError(t, err, context.Canceled.Error())
 				},
@@ -147,7 +147,7 @@ func TestServer_QueryTickets(t *testing.T) {
 						ref     = c.Doc(baseTicket.Path())
 						invalid = map[string]interface{}{
 							"TicketID":  "invalid",
-							"Deadline":  "invalid date",
+							"Deadline":  "invalid date", // important
 							"CreatedBy": baseTicket.CreatedBy,
 						}
 					)
@@ -188,6 +188,148 @@ func TestServer_QueryTickets(t *testing.T) {
 					ctx = tc.ctx
 				}
 				_, err = s.QueryTickets(ctx, tc.req)
+				tc.wantErr(t, err)
+			})
+		}
+	})
+}
+
+func TestServer_GetTicketById(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		cases := map[string]struct {
+			setupFirestore func(*firestore.Client) error
+
+			req *ticketquerierv1.GetTicketByIdRequest
+
+			want *ticketquerierv1.GetTicketByIdResponse
+		}{
+			"Return ticket": {
+				setupFirestore: func(c *firestore.Client) error {
+					bw := c.BulkWriter(context.Background())
+					if _, err := bw.Create(c.Doc(baseTicket.Path()), baseTicket); err != nil {
+						return err
+					}
+					bw.End()
+					return nil
+				},
+				req: &ticketquerierv1.GetTicketByIdRequest{
+					TicketId: baseTicket.TicketID,
+				},
+				want: &ticketquerierv1.GetTicketByIdResponse{
+					Ticket: &ticketquerierv1.Ticket{
+						TicketId: baseTicket.TicketID,
+						// CreatedAt
+						// UpdatedAt
+						CreatedBy:   baseTicket.CreatedBy,
+						Title:       baseTicket.Title,
+						Description: baseTicket.Description,
+						Deadline:    timestamppb.New(baseTicket.Deadline),
+					},
+				},
+			},
+		}
+		for name, tc := range cases {
+			t.Run(name, func(t *testing.T) {
+				fsc, err := firestoretest.InitFirestoreClient(context.Background(), modelfs.CollectionNameTickets)
+				if err != nil {
+					t.Fatalf("Failed to init firestore client: %v", err)
+				}
+
+				if err := tc.setupFirestore(fsc); err != nil {
+					t.Fatalf("Failed to setup firestore: %v", err)
+				}
+
+				s, err := querier.NewTicketQuerierServer(fsc)
+				if err != nil {
+					t.Fatalf("Failed to create server: %v", err)
+				}
+
+				res, err := s.GetTicketById(context.Background(), tc.req)
+				if !assert.NoError(t, err) {
+					return
+				}
+				if diff := cmp.Diff(tc.want, res,
+					protocmp.Transform(),
+					protocmp.IgnoreFields(&ticketquerierv1.Ticket{}, "created_at", "updated_at"),
+				); diff != "" {
+					t.Errorf("Response didn't match (-want / +got)\n%s", diff)
+				}
+			})
+		}
+	})
+
+	t.Run("Fail", func(t *testing.T) {
+		cases := map[string]struct {
+			setupFirestore func(*firestore.Client) error // optional
+
+			ctx context.Context // optional
+			req *ticketquerierv1.GetTicketByIdRequest
+
+			wantErr assert.ErrorAssertionFunc
+		}{
+			"Context cancelled": {
+				ctx: ctxtest.CanceledContext(), // important
+				wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
+					return assert.EqualError(t, err, context.Canceled.Error())
+				},
+			},
+			"NotFound: Ticket does not found": {
+				// setupFirestore // important
+				req: &ticketquerierv1.GetTicketByIdRequest{
+					TicketId: baseTicket.TicketID,
+				},
+				wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
+					return assert.ErrorContains(t, err, status.Error(codes.NotFound, "not found").Error())
+				},
+			},
+			"Internal: Failed to unmarshal": {
+				setupFirestore: func(c *firestore.Client) error {
+					var (
+						bw      = c.BulkWriter(context.Background())
+						ref     = c.Doc(baseTicket.Path())
+						invalid = map[string]interface{}{
+							"TicketID":  "invalid",
+							"Deadline":  "invalid date", // important
+							"CreatedBy": baseTicket.CreatedBy,
+						}
+					)
+					if _, err := bw.Create(ref, invalid); err != nil {
+						return err
+					}
+					bw.End()
+					return nil
+				},
+				req: &ticketquerierv1.GetTicketByIdRequest{
+					TicketId: baseTicket.TicketID,
+				},
+				wantErr: func(tt assert.TestingT, err error, i ...interface{}) bool {
+					return assert.ErrorContains(t, err, status.Error(codes.Internal, "failed to read").Error())
+				},
+			},
+		}
+		for name, tc := range cases {
+			t.Run(name, func(t *testing.T) {
+				fsc, err := firestoretest.InitFirestoreClient(context.Background(), modelfs.CollectionNameTickets)
+				if err != nil {
+					t.Fatalf("Failed to init firestore client: %v", err)
+				}
+
+				if tc.setupFirestore != nil {
+					if err := tc.setupFirestore(fsc); err != nil {
+						t.Fatalf("Failed to setup firestore: %v", err)
+					}
+				}
+
+				s, err := querier.NewTicketQuerierServer(fsc)
+				if err != nil {
+					t.Fatalf("Failed to create server: %v", err)
+				}
+
+				ctx := context.Background()
+				if tc.ctx != nil {
+					ctx = tc.ctx
+				}
+				_, err = s.GetTicketById(ctx, tc.req)
 				tc.wantErr(t, err)
 			})
 		}

--- a/go/lib/firestoretest/init.go
+++ b/go/lib/firestoretest/init.go
@@ -3,14 +3,16 @@ package firestoretest
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"cloud.google.com/go/firestore"
+	"github.com/google/uuid"
 	"google.golang.org/api/iterator"
 )
 
+var newFirestoreClient = firestore.NewClient
+
 func InitFirestoreClient(ctx context.Context, collections ...string) (*firestore.Client, error) {
-	fsc, err := firestore.NewClient(ctx, os.Getenv("FIRESTORE_PROJECT_ID"))
+	fsc, err := newFirestoreClient(ctx, uuid.NewString())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create firestore client: %w", err)
 	}

--- a/go/lib/firestoretest/init_test.go
+++ b/go/lib/firestoretest/init_test.go
@@ -59,18 +59,4 @@ func TestInitFirestoreClient(t *testing.T) {
 		_, err := firestoretest.InitFirestoreClient(ctxtest.CanceledContext(), "dummy")
 		assert.ErrorContains(t, err, "failed to remove all documents")
 	})
-
-	t.Run("Fail: Empty project id", func(t *testing.T) {
-		var (
-			envKey = "FIRESTORE_PROJECT_ID"
-			pid    = os.Getenv(envKey)
-		)
-		os.Setenv(envKey, "")
-		t.Cleanup(func() {
-			os.Setenv(envKey, pid)
-		})
-
-		_, err := firestoretest.InitFirestoreClient(context.Background(), "dummy")
-		assert.ErrorContains(t, err, "failed to create firestore client")
-	})
 }

--- a/go/lib/firestoretest/init_whitebox_test.go
+++ b/go/lib/firestoretest/init_whitebox_test.go
@@ -11,12 +11,25 @@ import (
 	"google.golang.org/api/option"
 )
 
-func Test_enqRemoveAllDocs(t *testing.T) {
+func TestInitFirestoreClient_fail(t *testing.T) {
+	t.Run("Failed to create firestore client", func(t *testing.T) {
+		newFirestoreClient = func(ctx context.Context, projectID string, opts ...option.ClientOption) (*firestore.Client, error) {
+			return nil, fmt.Errorf("some error")
+		}
+		t.Cleanup(func() {
+			newFirestoreClient = firestore.NewClient
+		})
+		_, err := InitFirestoreClient(context.Background())
+		assert.ErrorContains(t, err, "failed to create firestore client")
+	})
+}
+
+func Test_enqRemoveAllDocs_fail(t *testing.T) {
 	type DummyData struct {
 		ID string `firestore:"ID"`
 	}
 
-	t.Run("Fail: Empty project id", func(t *testing.T) {
+	t.Run("Use closed bulk writer", func(t *testing.T) {
 		ctx := context.Background()
 
 		fsc, err := firestore.NewClient(ctx, os.Getenv("FIRESTORE_PROJECT_ID"), option.WithScopes())

--- a/go/lib/firestorex/read.go
+++ b/go/lib/firestorex/read.go
@@ -1,6 +1,7 @@
 package firestorex
 
 import (
+	"context"
 	"fmt"
 	"iter"
 	"time"
@@ -42,4 +43,22 @@ func ReadEach[T any](iter *firestore.DocumentIterator) iter.Seq2[*ResultWithMeta
 			}
 		}
 	}
+}
+
+func ReadOne[T any](ctx context.Context, ref *firestore.DocumentRef) (*ResultWithMeta[T], error) {
+	doc, err := ref.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read: %w", err)
+	}
+
+	var d T
+	if err := doc.DataTo(&d); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal: %w", err)
+	}
+
+	return &ResultWithMeta[T]{
+		Data:       &d,
+		CreateTime: doc.CreateTime,
+		UpdateTime: doc.UpdateTime,
+	}, nil
 }


### PR DESCRIPTION
## Problem

[こちら](https://github.com/t-ash0410/stack-example/pull/12)の方針でテスト時のデータ競合を回避したつもりだったが、Firestore Clientを初期化する際に全てのデータを削除している部分について考慮漏れしており、事前に準備したデータがテスト実行時に削除される事象が発生した。

## Solution

Firestore Emulatorの挙動を調査したところ、Project IDを都度採番することによってデータ領域を分けることに成功した。